### PR TITLE
Feat/misc key value pairs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,7 +64,7 @@ requests from a private network.
 curl https://raw.githubusercontent.com/openflighthpc/flight-message/master/support/install-centos7.sh | bash
 ```
 
-# Setting up clients
+# Setting Up Clients
 
 There is also a one line curl for setting up a machine as a client, sending power information to flight message once and hour. That line is:
 
@@ -72,7 +72,21 @@ There is also a one line curl for setting up a machine as a client, sending powe
 curl https://raw.githubusercontent.com/openflighthpc/flight-message/master/support/setup-client.sh | bash -s IP_OF_SERVER
 ```
 
-Where 'IP_OF_SERVER' is the address of the the server machine, set up as above.
+Where 'IP_OF_SERVER' is the address of the server machine, set up as above.
+
+# Ganglia Integration
+
+There is also a script for exporting Message data to an existing, preconfigured Ganglia server.
+It will export key-value pairs in each asset's most recent status as floats using `gmetric`.
+It will try its best to split this value into a numerical value and units (if present) - IT IS
+NOT DESIGNED TO WORK WITH NON-NUMERICAL VALUES, any values that can't be cast to a float will
+be ignored by Ganglia.
+
+The script is found at support/output_via_gmetric.rb. It should be ran regularly on the server
+via a cron job or equivalent.
+
+It is also potentially very fragile in general; it has only been tested with a restricted set
+of key-value pairs and should be used with care.
 
 # Testing
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ swapped out and deleted.
 
 ```
 
-create TYPE ASSET TEXT [-l LIFESPAN]
+create TYPE ASSET TEXT [KEY=VALUE...] [-l LIFESPAN]
 
 delete ID
 

--- a/lib/flight-message/cli.rb
+++ b/lib/flight-message/cli.rb
@@ -53,7 +53,7 @@ module FlightMessage
     end
 
     command :create do |c|
-      cli_syntax(c, 'TYPE ASSET TEXT')
+      cli_syntax(c, 'TYPE ASSET TEXT [KEY=VALUE...]')
       c.description = "Create a new message"
       c.option '-l', '--lifespan PERIOD',
         'Set a time of expiry for the message - '\

--- a/lib/flight-message/commands/create.rb
+++ b/lib/flight-message/commands/create.rb
@@ -34,7 +34,10 @@ module FlightMessage
     class Create < Command
       def run
         msg = Message.new()
-        msg.create(*@argv[0..2], ClustersConfig.current, @options.lifespan)
+        msg.create(*@argv[0..2],
+                   key_val_arr = @argv[3..-1],
+                   cluster = ClustersConfig.current,
+                   lifespan = @options.lifespan)
         msg.save
       end
     end

--- a/lib/flight-message/commands/show.rb
+++ b/lib/flight-message/commands/show.rb
@@ -53,33 +53,36 @@ module FlightMessage
                      end
 
         asset_dirs.sort!
-        asset_dirs.each do |asset_dir|
-          messages = Message.load_dir(asset_dir)
-          status_msg, info = messages.partition { |m| m.data['type'] == 'status' }
-          header = "##{File.basename(asset_dir)}:"
 
-          misc = []
-          unless status_msg.empty?
-            mid_string = ' STATUS '
-            status = status_msg[0]
-            header = header + "#{mid_string}- #{status.data['text']}"
-            if status.data['misc']
-              # work out padding to allign text
-              n = header.rindex(mid_string) + mid_string.length
-              status.data['misc'].each do |key, val|
-                str = "- #{key} = #{val}"
-                (0...n).each { str = ' ' + str }
-                misc << str
-              end
+        asset_dirs.each { |asset_dir| output_asset(asset_dir) }
+      end
+
+      def output_asset(asset_dir)
+        messages = Message.load_dir(asset_dir)
+        status_msg, info = messages.partition { |m| m.data['type'] == 'status' }
+        header = "##{File.basename(asset_dir)}:"
+
+        misc = []
+        unless status_msg.empty?
+          mid_string = ' STATUS '
+          status = status_msg[0]
+          header = header + "#{mid_string}- #{status.data['text']}"
+          if status.data['misc']
+            # work out padding to allign text
+            n = header.rindex(mid_string) + mid_string.length
+            status.data['misc'].each do |key, val|
+              str = "- #{key} = #{val}"
+              (0...n).each { str = ' ' + str }
+              misc << str
             end
           end
-          puts header
-          puts misc unless misc.empty?
-
-          info = info.sort_by { |m| m.data['received'] }.reverse
-          info.each { |i| puts "  #{i.data['received']} - #{i.id} - #{i.data['text']}" }
-          puts
         end
+        puts header
+        puts misc unless misc.empty?
+
+        info = info.sort_by { |m| m.data['received'] }.reverse
+        info.each { |i| puts "  #{i.data['received']} - #{i.id} - #{i.data['text']}" }
+        puts
       end
     end
   end

--- a/lib/flight-message/commands/show.rb
+++ b/lib/flight-message/commands/show.rb
@@ -56,11 +56,26 @@ module FlightMessage
         asset_dirs.each do |asset_dir|
           messages = Message.load_dir(asset_dir)
           status_msg, info = messages.partition { |m| m.data['type'] == 'status' }
-          header = "##{File.basename(asset_dir)}"
+          header = "##{File.basename(asset_dir)}:"
+
+          misc = []
           unless status_msg.empty?
-            header = header + ":  STATUS - #{status_msg[0].data['text']}"
+            mid_string = ' STATUS '
+            status = status_msg[0]
+            header = header + "#{mid_string}- #{status.data['text']}"
+            if status.data['misc']
+              # work out padding to allign text
+              n = header.rindex(mid_string) + mid_string.length
+              status.data['misc'].each do |key, val|
+                str = "- #{key} = #{val}"
+                (0...n).each { str = ' ' + str }
+                misc << str
+              end
+            end
           end
           puts header
+          puts misc unless misc.empty?
+
           info = info.sort_by { |m| m.data['received'] }.reverse
           info.each { |i| puts "  #{i.data['received']} - #{i.id} - #{i.data['text']}" }
           puts

--- a/lib/flight-message/message.rb
+++ b/lib/flight-message/message.rb
@@ -93,7 +93,7 @@ module FlightMessage
       @id = id
     end
 
-    def create(type, asset, text, cluster = nil, lifespan = nil)
+    def create(type, asset, text, key_val_arr = [], cluster = nil, lifespan = nil)
       type = soft_match_type(type)
       cluster ||= ClustersConfig.current
       @asset = asset
@@ -103,6 +103,14 @@ module FlightMessage
       received = Time.now
       data['received'] = received.iso8601
       data['expiry'] = parse_lifespan(lifespan, received).iso8601 if lifespan
+      key_val_arr.each do |str|
+        data['misc'] ||= {}
+        unless str.split(/=/).length == 2
+          raise ArgumentError, "Invalid key-value argument '#{str}' - must contain one '='"
+        end
+        key, val = str.split(/=/)
+        data['misc'][key] = val
+      end
     end
 
     def load_from_id(id = @id)

--- a/support/apache_server_conf-centos7.sh
+++ b/support/apache_server_conf-centos7.sh
@@ -44,13 +44,13 @@ mkdir -p /opt/flight/opt/message/export/exec
 
 cat << 'EOF' > /opt/flight/opt/message/export/exec/create_status.php
 <?php
-$text = "OK";
+$extra = "";
 $keys = array_keys($_GET);
 /* starting at index 1 as 'asset' is expected to be the first elem */
 for($i=1; $i < count($_GET); ++$i) {
-  $text .= " | {$keys[$i]} = {$_GET[$keys[$i]]}";
+  $extra .= " \"{$keys[$i]}\"=\"{$_GET[$keys[$i]]}\"";
 }
-$cmd = "sudo /opt/flight/bin/flight message create status {$_GET['asset']} \"{$text}\" --lifespan 1h";
+$cmd = "sudo /opt/flight/bin/flight message create status {$_GET['asset']} OK {$extra} --lifespan 1h";
 echo exec(escapeshellcmd($cmd));
 ?>
 EOF

--- a/support/apache_server_conf-centos7.sh
+++ b/support/apache_server_conf-centos7.sh
@@ -26,7 +26,7 @@
 # https://github.com/openflighthpc/flight-message
 # ==============================================================================
 
-yum -y install httpd php
+yum -y install httpd php syslinux
 
 cat << EOF > /etc/httpd/conf.d/collector.conf
 <Directory /opt/flight/opt/message/export/>

--- a/support/output_via_gmetric.rb
+++ b/support/output_via_gmetric.rb
@@ -26,10 +26,11 @@
 # https://github.com/openflighthpc/flight-message
 # ==============================================================================
 
-# CURRENTLY DESIGNED TO WORK ONLY WITH METRICS THAT HAVE EXCLUSIVELY NUMERICAL VALUES.
-# Will need modification if any string values are expected.
-
 require 'open3'
+
+def is_number?(value)
+  true if Float(value) rescue false
+end
 
 show_data, _, status = Open3.capture3('/opt/flight/bin/flight message show')
 unless status.exitstatus == 0
@@ -55,7 +56,8 @@ assets_text.each do |a|
       value = split[0]
       unit = split[1..-1].join(' ')
     end
-    cmd = "gmetric -S #{ip}:#{asset} -n #{key} -v #{value} -t float -g flight_message"
+    type = is_number?(value) ? 'float' : 'string'
+    cmd = "gmetric -S #{ip}:#{asset} -n #{key} -v #{value} -t #{type} -g flight_message"
     cmd = cmd + " -u #{unit}" if unit
     Open3.capture3(cmd)
   end

--- a/support/output_via_gmetric.rb
+++ b/support/output_via_gmetric.rb
@@ -26,7 +26,6 @@
 # https://github.com/openflighthpc/flight-message
 # ==============================================================================
 
-
 # CURRENTLY DESIGNED TO WORK ONLY WITH METRICS THAT HAVE EXCLUSIVELY NUMERICAL VALUES.
 # Will need modification if any string values are expected.
 
@@ -42,11 +41,13 @@ assets_text = show_data.split(/^#/).delete_if { |a| a.empty? }
 assets_text.each do |a|
   lines = a.split(/\n/)
   asset = lines.shift.match(/^(.*?):/)[1]
+
   ip = Open3.capture3("gethostip -d #{asset}")[0].chomp
   if not ip or ip.match(/\s+/)
     puts "ERROR: Cant' find an ip for asset '#{asset}' - skipping"
     next
   end
+
   key_lines = lines.partition { |line| line.match(/^\s*-/) }[0]
   key_lines.each do |line|
     key, value = line.match(/- (.*) = (.*)$/)[1..2]

--- a/support/output_via_gmetric.rb
+++ b/support/output_via_gmetric.rb
@@ -47,7 +47,7 @@ assets_text.each do |a|
     puts "ERROR: Cant' find an ip for asset '#{asset}' - skipping"
     next
   end
-  key_lines = lines.partition { |line| line.match(/\s*-/) }[0]
+  key_lines = lines.partition { |line| line.match(/^\s*-/) }[0]
   key_lines.each do |line|
     key, value = line.match(/- (.*) = (.*)$/)[1..2]
     if split = value.split(' ') and split.length > 1

--- a/support/output_via_gmetric.rb
+++ b/support/output_via_gmetric.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+# =============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Message.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Message is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Message. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Message, please visit:
+# https://github.com/openflighthpc/flight-message
+# ==============================================================================
+
+
+# CURRENTLY DESIGNED TO WORK ONLY WITH METRICS THAT HAVE EXCLUSIVELY NUMERICAL VALUES.
+# Will need modification if any string values are expected.
+
+require 'open3'
+
+show_data, _, status = Open3.capture3('/opt/flight/bin/flight message show')
+unless status.exitstatus == 0
+  raise RuntimeError, "Error accessing Flight Message"
+end
+
+assets_text = show_data.split(/^#/).delete_if { |a| a.empty? }
+
+assets_text.each do |a|
+  lines = a.split(/\n/)
+  asset = lines.shift.match(/^(.*?):/)[1]
+  ip = Open3.capture3("gethostip -d #{asset}")[0].chomp
+  if not ip or ip.match(/\s+/)
+    puts "ERROR: Cant' find an ip for asset '#{asset}' - skipping"
+    next
+  end
+  key_lines = lines.partition { |line| line.match(/\s*-/) }[0]
+  key_lines.each do |line|
+    key, value = line.match(/- (.*) = (.*)$/)[1..2]
+    if split = value.split(' ') and split.length > 1
+      value = split[0]
+      unit = split[1..-1].join(' ')
+    end
+    cmd = "gmetric -S #{ip}:#{asset} -n #{key} -v #{value} -t float -g flight_message"
+    cmd = cmd + " -u #{unit}" if unit
+    Open3.capture3(cmd)
+  end
+end

--- a/support/setup-client.sh
+++ b/support/setup-client.sh
@@ -31,17 +31,21 @@ if [[ $# -eq 0 ]] ; then
   exit 0
 fi
 
-mkdir -p /opt/service/message/
-
 yum install -y curl ruby
 
-curl https://raw.githubusercontent.com/openflighthpc/flight-message/master/scripts/collectors/collect_power.rb > /opt/service/message/collect_power.rb
+FILE=/opt/service/message/collect_power.rb
 
-chown root:root /opt/service/message/collect_power.rb
-chmod 700 /opt/service/message/collect_power.rb
+if [[ ! -f $FILE ]]; then
+  mkdir -p /opt/service/message/
+
+  curl https://raw.githubusercontent.com/openflighthpc/flight-message/master/scripts/collectors/collect_power.rb > $FILE
+
+  chown root:root $FILE
+  chmod 700 $FILE
+fi
 
 echo "#!/bin/bash" > /etc/cron.hourly/flight_message_collect_power
-echo "export FLIGHT_MESSAGE_SERVER=$1 && /opt/service/message/collect_power.rb" >> /etc/cron.hourly/flight_message_collect_power
+echo "export FLIGHT_MESSAGE_SERVER=$1 && $FILE" >> /etc/cron.hourly/flight_message_collect_power
 
 chown root:root /etc/cron.hourly/flight_message_collect_power
 chmod 700 /etc/cron.hourly/flight_message_collect_power


### PR DESCRIPTION
Tweaks some core functionality such that:
 - the create command takes any number of arguments with all argument past the 3rd being optional key/value pairs in the form a=b
 - These pairs will be specially stored in the YAML file
 - All of the most recent status' key/value pairs will be displayed in a `show` command's output

Tweaks to peripheral things to take advantage of this:
 - The php script set up during server config now converts the query string to these key/value pairs
 - We've added a script for exporting to Ganglia servers! Please see the INSTALL.md doc changes for more info